### PR TITLE
Add operations documentation for test execution, monitoring, and scheduling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ nbproject/
 *.swp
 *.swo
 *~
+.claude
 ###< IDE ###
 
 ###> PHP Tooling ###

--- a/README.md
+++ b/README.md
@@ -246,12 +246,26 @@ docker-compose logs -f matre_test_worker
 
 ## Documentation
 
+### Getting Started
 - [Installation Guide](docs/getting-started/installation.md)
 - [Configuration](docs/getting-started/configuration.md)
+
+### Operations
+- [Running Tests](docs/operations/test-execution.md) - Execute MFTF/Playwright tests
+- [Allure Reports](docs/operations/allure-reports.md) - View and manage reports
+- [Monitoring](docs/operations/monitoring.md) - Health checks and diagnostics
+- [Scheduling](docs/operations/scheduling.md) - Automate test runs
+- [CLI Reference](docs/operations/cli-reference.md) - All commands
+- [API Reference](docs/operations/api-reference.md) - REST API
+- [Troubleshooting](docs/operations/troubleshooting.md) - Common issues
+
+### Development
 - [Architecture Overview](docs/development/architecture.md)
 - [Entities](docs/development/entities.md)
 - [Admin CRUD](docs/development/admin-crud.md)
-- [Testing](docs/testing/testing.md)
+- [Unit Tests](docs/testing/unit-tests.md) - PHPUnit testing
+
+### Deployment
 - [Production Deployment](docs/deployment/production.md)
 - [CI/CD](docs/deployment/ci-cd.md)
 - [Security](docs/security.md)

--- a/docs/operations/allure-reports.md
+++ b/docs/operations/allure-reports.md
@@ -1,0 +1,161 @@
+# Allure Reports
+
+Managing test reports: viewing, retention, and cleanup.
+
+---
+
+## Accessing Reports
+
+### From Admin UI
+
+1. Open completed test run in **Test Runs**
+2. Click **View Report** button
+3. Allure HTML report opens in new tab
+
+### Direct URL
+
+```
+http://localhost:5050/allure-docker-service/projects/run-{id}/reports/latest
+```
+
+Replace `{id}` with test run ID. Example:
+```
+http://localhost:5050/allure-docker-service/projects/run-42/reports/latest
+```
+
+### Via API
+
+Get report URL from test run details:
+```bash
+curl http://localhost:8089/api/test-runs/42
+```
+
+Response includes `reports` array with `publicUrl` for each report.
+
+---
+
+## Report Contents
+
+Allure HTML reports include:
+
+| Section | Description |
+|---------|-------------|
+| **Overview** | Pass/fail pie chart, total duration, environment info |
+| **Suites** | Test hierarchy with status per test |
+| **Graphs** | Historical trends (if previous runs exist) |
+| **Timeline** | Test execution timeline visualization |
+| **Categories** | Failure categorization (product bugs, test issues) |
+| **Behaviors** | Tests organized by feature/story |
+| **Packages** | Tests organized by package/namespace |
+
+### Result Merging
+
+When running **Both** test types, results from MFTF and Playwright are merged into a single report showing combined coverage.
+
+---
+
+## Retention Policy
+
+- **Default retention:** 30 days
+- Reports automatically expire after retention period
+- Expired reports removed by cleanup job
+
+---
+
+## Cleanup {#cleanup}
+
+### Automatic Cleanup
+
+A scheduled job runs daily to remove expired reports and artifacts.
+
+### Manual Cleanup
+
+Preview what will be deleted (dry run):
+```bash
+docker-compose exec php php bin/console app:test:cleanup --dry-run
+```
+
+Output:
+```
+[DRY RUN] Would delete:
+- 15 test runs older than 30 days
+- 15 Allure report directories
+- 42 artifact directories
+```
+
+Execute cleanup:
+```bash
+docker-compose exec php php bin/console app:test:cleanup
+```
+
+### Options
+
+| Option | Example | Description |
+|--------|---------|-------------|
+| `--days` | `--days=7` | Custom retention period |
+| `--dry-run` | `--dry-run` | Preview without deleting |
+| `--reports-only` | `--reports-only` | Only delete reports, keep test run records |
+
+### Examples
+
+```bash
+# Delete everything older than 7 days
+docker-compose exec php php bin/console app:test:cleanup --days=7
+
+# Preview reports cleanup only
+docker-compose exec php php bin/console app:test:cleanup --reports-only --dry-run
+
+# Force cleanup of all reports older than 1 day
+docker-compose exec php php bin/console app:test:cleanup --days=1 --reports-only
+```
+
+---
+
+## Allure Service Health
+
+### Check Service Status
+
+```bash
+curl http://localhost:5050/allure-docker-service/version
+```
+
+Expected: Version string like `"2.24.0"`
+
+### View Logs
+
+```bash
+docker-compose logs allure
+docker-compose logs -f allure  # Follow logs
+```
+
+### Restart Service
+
+```bash
+docker-compose restart allure
+```
+
+### List All Projects
+
+```bash
+curl http://localhost:5050/allure-docker-service/projects
+```
+
+---
+
+## Storage Locations
+
+| Type | Path |
+|------|------|
+| Allure results (JSON) | `var/allure-results/run-{id}/` |
+| MFTF results | `var/mftf-results/` |
+| Playwright results | `var/playwright-results/` |
+| Test artifacts | `var/test-artifacts/{runId}/` |
+
+---
+
+## Troubleshooting
+
+See [Troubleshooting Guide](troubleshooting.md#reports) for common issues:
+- Report not generating
+- Report shows no data
+- Screenshots not loading

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -1,0 +1,387 @@
+# API Reference
+
+REST API for programmatic access to MATRE.
+
+---
+
+## Authentication
+
+### Browser Sessions
+
+Standard session-based authentication via `/login` form.
+
+### Programmatic Access
+
+Currently session-based. Obtain session cookie by:
+1. POST to `/login` with credentials
+2. Include session cookie in subsequent requests
+
+### CSRF Protection
+
+All POST/PUT/DELETE requests require CSRF token:
+- Header: `X-CSRF-TOKEN: {token}`
+- Or form field: `_token={token}`
+
+Get token from any HTML page's meta tag or form.
+
+---
+
+## Dashboard API
+
+### GET /api/dashboard/stats
+
+Real-time system statistics.
+
+**Response:**
+```json
+{
+  "users": {
+    "total": 5,
+    "active": 4,
+    "inactive": 1
+  },
+  "testRuns": {
+    "total": 150,
+    "completed": 120,
+    "failed": 20,
+    "running": 5,
+    "pending": 5
+  },
+  "environments": {
+    "total": 3,
+    "active": 3
+  },
+  "suites": {
+    "total": 8,
+    "active": 6,
+    "scheduled": 3
+  },
+  "activity": {
+    "running": 2
+  }
+}
+```
+
+**Notes:**
+- `testRuns` counts are for last 30 days
+- `activity.running` is current active test count
+
+---
+
+## Test Runs API {#test-runs}
+
+### GET /api/test-runs
+
+List test runs with pagination and filtering.
+
+**Query Parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `page` | int | 1 | Page number |
+| `limit` | int | 20 | Items per page (max: 100) |
+| `status` | string | - | Filter: `pending`, `running`, `completed`, `failed`, `canceled` |
+| `type` | string | - | Filter: `mftf`, `playwright`, `both` |
+| `environment` | int | - | Filter by environment ID |
+
+**Example:**
+```bash
+curl "http://localhost:8089/api/test-runs?status=completed&limit=10"
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": 42,
+      "status": "completed",
+      "type": "mftf",
+      "trigger": "manual",
+      "duration": "5m 23s",
+      "environment": {
+        "id": 1,
+        "name": "Staging",
+        "code": "staging"
+      },
+      "suite": {
+        "id": 3,
+        "name": "Smoke Tests"
+      },
+      "resultCounts": {
+        "passed": 95,
+        "failed": 2,
+        "skipped": 3,
+        "total": 100
+      },
+      "createdAt": "2025-01-15T10:30:00Z",
+      "startedAt": "2025-01-15T10:30:05Z",
+      "completedAt": "2025-01-15T10:35:28Z"
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "limit": 10,
+    "total": 150,
+    "pages": 15
+  }
+}
+```
+
+---
+
+### GET /api/test-runs/{id}
+
+Get detailed test run with all results.
+
+**Example:**
+```bash
+curl "http://localhost:8089/api/test-runs/42"
+```
+
+**Response:**
+```json
+{
+  "id": 42,
+  "status": "completed",
+  "type": "mftf",
+  "trigger": "manual",
+  "filter": "SmokeTestGroup",
+  "duration": "5m 23s",
+  "environment": {
+    "id": 1,
+    "name": "Staging",
+    "code": "staging",
+    "baseUrl": "https://staging.example.com"
+  },
+  "suite": {
+    "id": 3,
+    "name": "Smoke Tests"
+  },
+  "resultCounts": {
+    "passed": 95,
+    "failed": 2,
+    "skipped": 3,
+    "total": 100
+  },
+  "results": [
+    {
+      "id": 1001,
+      "testName": "StorefrontCheckoutTest",
+      "status": "passed",
+      "duration": 12500,
+      "errorMessage": null,
+      "screenshotPath": null
+    },
+    {
+      "id": 1002,
+      "testName": "AdminCreateProductTest",
+      "status": "failed",
+      "duration": 8200,
+      "errorMessage": "Element #save-button not found",
+      "screenshotPath": "/test-artifacts/42/screenshot-1002.png"
+    }
+  ],
+  "reports": [
+    {
+      "id": 15,
+      "type": "allure",
+      "publicUrl": "http://localhost:5050/allure-docker-service/projects/run-42/reports/latest",
+      "expiresAt": "2025-02-14T10:35:28Z"
+    }
+  ],
+  "createdAt": "2025-01-15T10:30:00Z",
+  "startedAt": "2025-01-15T10:30:05Z",
+  "completedAt": "2025-01-15T10:35:28Z"
+}
+```
+
+---
+
+### POST /api/test-runs
+
+Create new test run.
+
+**Request Body:**
+```json
+{
+  "environmentId": 1,
+  "type": "mftf",
+  "suiteId": 3,
+  "filter": "CheckoutTest"
+}
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `environmentId` | Yes | int | Target environment ID |
+| `type` | No | string | `mftf`, `playwright`, `both` (default: `mftf`) |
+| `suiteId` | No | int | Predefined suite ID |
+| `filter` | No | string | Test name/group pattern |
+
+**Response:**
+```json
+{
+  "id": 43,
+  "status": "pending",
+  "message": "Test run created and queued for execution"
+}
+```
+
+**Example:**
+```bash
+curl -X POST "http://localhost:8089/api/test-runs" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-TOKEN: {token}" \
+  -d '{"environmentId": 1, "type": "mftf", "filter": "SmokeTestGroup"}'
+```
+
+---
+
+### POST /api/test-runs/{id}/cancel
+
+Cancel a running test.
+
+**Requirements:**
+- Test must be in `running` or `pending` status
+- User must have `ROLE_ADMIN`
+
+**Response:**
+```json
+{
+  "id": 42,
+  "status": "canceled",
+  "message": "Test run canceled successfully"
+}
+```
+
+---
+
+### POST /api/test-runs/{id}/retry
+
+Retry a failed test.
+
+**Requirements:**
+- Test must be in `failed` or `canceled` status
+
+**Response:**
+```json
+{
+  "id": 42,
+  "status": "pending",
+  "message": "Test run queued for retry"
+}
+```
+
+---
+
+## Response Format
+
+### Success Response
+
+```json
+{
+  "data": { ... },
+  "meta": { ... }
+}
+```
+
+Or for single items:
+```json
+{
+  "id": 42,
+  ...
+}
+```
+
+### Error Response
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid environment ID",
+    "details": {
+      "field": "environmentId",
+      "value": 999
+    }
+  }
+}
+```
+
+### Common Error Codes
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `VALIDATION_ERROR` | 400 | Invalid request data |
+| `NOT_FOUND` | 404 | Resource not found |
+| `UNAUTHORIZED` | 401 | Authentication required |
+| `FORBIDDEN` | 403 | Insufficient permissions |
+| `CONFLICT` | 409 | Resource conflict (e.g., environment locked) |
+| `SERVER_ERROR` | 500 | Internal server error |
+
+---
+
+## Rate Limiting
+
+API requests are rate limited:
+
+| Limit | Value |
+|-------|-------|
+| Average | 100 requests/minute |
+| Burst | 50 requests |
+
+**Response Headers:**
+- `X-RateLimit-Limit` - Max requests per window
+- `X-RateLimit-Remaining` - Remaining requests
+- `X-RateLimit-Reset` - Seconds until reset
+
+**Rate Limited Response (429):**
+```json
+{
+  "error": {
+    "code": "RATE_LIMITED",
+    "message": "Too many requests",
+    "details": {
+      "retryAfter": 30
+    }
+  }
+}
+```
+
+---
+
+## Examples
+
+### Create and Monitor Test Run
+
+```bash
+# Create test run
+RUN_ID=$(curl -s -X POST "http://localhost:8089/api/test-runs" \
+  -H "Content-Type: application/json" \
+  -d '{"environmentId": 1, "type": "mftf"}' | jq -r '.id')
+
+echo "Created run: $RUN_ID"
+
+# Poll until complete
+while true; do
+  STATUS=$(curl -s "http://localhost:8089/api/test-runs/$RUN_ID" | jq -r '.status')
+  echo "Status: $STATUS"
+
+  if [ "$STATUS" = "completed" ] || [ "$STATUS" = "failed" ]; then
+    break
+  fi
+
+  sleep 10
+done
+
+# Get final results
+curl -s "http://localhost:8089/api/test-runs/$RUN_ID" | jq '.resultCounts'
+```
+
+### Get Failed Tests
+
+```bash
+curl -s "http://localhost:8089/api/test-runs?status=failed&limit=5" | \
+  jq '.data[] | {id, environment: .environment.name, failed: .resultCounts.failed}'
+```

--- a/docs/operations/cli-reference.md
+++ b/docs/operations/cli-reference.md
@@ -1,0 +1,54 @@
+# CLI Reference
+
+All MATRE commands. Click links for detailed usage.
+
+---
+
+## Test Operations
+
+| Command | Purpose | Guide |
+|---------|---------|-------|
+| `app:test:run` | Execute MFTF/Playwright tests | [Test Execution](test-execution.md#cli) |
+| `app:test:check-magento` | Pre-flight health check | [Monitoring](monitoring.md#pre-flight) |
+| `app:test:cleanup` | Remove old artifacts/reports | [Allure Reports](allure-reports.md#cleanup) |
+
+---
+
+## Scheduling
+
+| Command | Purpose | Guide |
+|---------|---------|-------|
+| `app:cron:list` | Show scheduled jobs | [Scheduling](scheduling.md#list-jobs) |
+| `app:cron:run {id}` | Run job manually | [Scheduling](scheduling.md#manual-run) |
+| `app:cron:install` | Add to system crontab | [Scheduling](scheduling.md#system-install) |
+| `app:cron:remove` | Remove from crontab | [Scheduling](scheduling.md#system-install) |
+
+---
+
+## Setup
+
+See [Installation Guide](../getting-started/installation.md) for full setup instructions.
+
+| Command | Purpose |
+|---------|---------|
+| `app:database:setup` | Initialize database (drop, create, migrate, fixtures) |
+| `app:create-admin` | Create admin user (interactive) |
+| `app:create-user` | Create regular user (interactive) |
+| `app:load-fixtures` | Load sample data |
+
+---
+
+## Data Import
+
+| Command | Purpose |
+|---------|---------|
+| `app:env:import` | Import .env variables with MFTF usage analysis |
+| `app:test:import-env` | Bulk import test environments from .env files |
+
+---
+
+## Validation
+
+| Command | Purpose |
+|---------|---------|
+| `app:validate-ssl-config` | Check SSL/Traefik configuration for production |

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -1,0 +1,220 @@
+# Monitoring & Health Checks
+
+System diagnostics and health monitoring.
+
+---
+
+## Pre-Flight Validation {#pre-flight}
+
+Run before test execution to verify system readiness:
+
+```bash
+docker-compose exec php php bin/console app:test:check-magento
+```
+
+### Checks Performed
+
+| Check | Description |
+|-------|-------------|
+| Docker containers | Verify required containers are running |
+| Magento version | Detect Magento version in test environment |
+| MFTF binary | Verify `vendor/bin/mftf` is available |
+| Selenium Grid | Test connection to selenium-hub |
+| Allure service | Verify Allure API responds |
+
+### Example Output
+
+```
+MATRE Pre-Flight Check
+======================
+
+[OK] Docker: matre_magento container running
+[OK] Magento: Version 2.4.6-p3 detected
+[OK] MFTF: vendor/bin/mftf available
+[OK] Selenium: Hub at selenium-hub:4444 responding (4 nodes)
+[OK] Allure: Service at allure:5050 healthy (v2.24.0)
+
+All checks passed. Ready for test execution.
+```
+
+### Failed Check Example
+
+```
+[OK] Docker: matre_magento container running
+[OK] Magento: Version 2.4.6-p3 detected
+[OK] MFTF: vendor/bin/mftf available
+[FAIL] Selenium: Connection refused to selenium-hub:4444
+[OK] Allure: Service at allure:5050 healthy
+
+1 check failed. See troubleshooting guide.
+```
+
+---
+
+## Dashboard Statistics
+
+### API Endpoint
+
+```bash
+curl http://localhost:8089/api/dashboard/stats
+```
+
+### Response
+
+```json
+{
+  "users": {
+    "total": 5,
+    "active": 4,
+    "inactive": 1
+  },
+  "testRuns": {
+    "total": 150,
+    "completed": 120,
+    "failed": 25,
+    "running": 3,
+    "pending": 2
+  },
+  "environments": {
+    "total": 5,
+    "active": 4
+  },
+  "suites": {
+    "total": 10,
+    "active": 8,
+    "scheduled": 3
+  },
+  "activity": {
+    "running": 2
+  }
+}
+```
+
+### Metrics Explained
+
+| Metric | Description |
+|--------|-------------|
+| `testRuns.running` | Currently executing tests |
+| `testRuns.pending` | Queued tests waiting to start |
+| `testRuns.failed` | Failed runs in last 30 days |
+| `suites.scheduled` | Suites with active cron scheduling |
+| `activity.running` | Current active test count |
+
+---
+
+## Service Health Checks
+
+Quick health verification for each service:
+
+| Service | Command | Expected |
+|---------|---------|----------|
+| **App** | `curl http://localhost:8089` | HTTP 200 |
+| **Selenium** | `curl http://localhost:4444/status` | JSON with `"ready": true` |
+| **Allure** | `curl http://localhost:5050/allure-docker-service/version` | Version string |
+| **Mailpit** | `curl http://localhost:8031` | HTTP 200 |
+| **Database** | `docker-compose exec db mysqladmin ping -umatre -pmatre` | `mysqld is alive` |
+
+### Selenium Grid Details
+
+```bash
+curl http://localhost:4444/status | jq '.value.ready, .value.nodes'
+```
+
+Shows grid ready state and available browser nodes.
+
+---
+
+## Log Monitoring
+
+### Test Worker
+
+Test execution logs:
+```bash
+docker-compose logs -f matre_test_worker
+```
+
+### Scheduler
+
+Cron job execution logs:
+```bash
+docker-compose logs -f matre_scheduler
+```
+
+### All Services
+
+```bash
+docker-compose logs -f
+```
+
+### Specific Container
+
+```bash
+# Last 100 lines
+docker-compose logs --tail=100 matre_php
+
+# Follow with timestamps
+docker-compose logs -f -t matre_php
+```
+
+---
+
+## Queue Health
+
+### Check Pending Messages
+
+```bash
+docker-compose exec db mysql -umatre -pmatre -e \
+  "SELECT queue_name, COUNT(*) as pending FROM matre.messenger_messages GROUP BY queue_name;"
+```
+
+Expected queues:
+- `test_runner` - Test execution messages
+- `scheduler_test_runner` - Scheduled test messages
+- `async` - Email/notification messages
+
+### Check Failed Messages
+
+```bash
+docker-compose exec db mysql -umatre -pmatre -e \
+  "SELECT id, queue_name, created_at FROM matre.messenger_messages WHERE queue_name = 'failed' ORDER BY created_at DESC LIMIT 10;"
+```
+
+### Retry Failed Message
+
+Failed messages can be retried via Symfony console:
+```bash
+docker-compose exec php php bin/console messenger:failed:show
+docker-compose exec php php bin/console messenger:failed:retry {id}
+```
+
+---
+
+## Container Status
+
+### Quick Status
+
+```bash
+docker-compose ps
+```
+
+### Detailed Status
+
+```bash
+docker-compose ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
+```
+
+### Resource Usage
+
+```bash
+docker stats --no-stream
+```
+
+---
+
+## Common Issues
+
+See [Troubleshooting Guide](troubleshooting.md) for solutions to:
+- Selenium Grid disconnected
+- Allure service unresponsive
+- Worker not processing
+- Queue backlog

--- a/docs/operations/scheduling.md
+++ b/docs/operations/scheduling.md
@@ -1,0 +1,232 @@
+# Test Scheduling
+
+Automate test execution with cron-based scheduling.
+
+---
+
+## Overview
+
+MATRE supports automated test runs via cron expressions. Scheduled tests:
+- Run automatically at specified intervals
+- Use environment locking to prevent conflicts
+- Track execution history and status
+- Support all test types (MFTF, Playwright, Both)
+
+---
+
+## Configure Scheduled Tests
+
+### Via Admin UI
+
+1. Navigate to **Test Suites**
+2. Click **Edit** on a suite
+3. Enable **Scheduled** checkbox
+4. Enter **Cron Expression**
+5. Select **Environment** for scheduled runs
+6. Click **Save**
+
+### Required Fields
+
+| Field | Description |
+|-------|-------------|
+| Scheduled | Enable/disable scheduling |
+| Cron Expression | When to run (see syntax below) |
+| Environment | Target environment for scheduled runs |
+| Test Type | MFTF, Playwright, or Both |
+
+---
+
+## Cron Expression Syntax
+
+Standard 5-field cron format:
+
+```
+┌───────────── minute (0-59)
+│ ┌───────────── hour (0-23)
+│ │ ┌───────────── day of month (1-31)
+│ │ │ ┌───────────── month (1-12)
+│ │ │ │ ┌───────────── day of week (0-6, Sunday=0)
+│ │ │ │ │
+* * * * *
+```
+
+### Common Examples
+
+| Expression | Schedule |
+|------------|----------|
+| `0 2 * * *` | Daily at 2:00 AM |
+| `0 */6 * * *` | Every 6 hours |
+| `30 1 * * 1-5` | Weekdays at 1:30 AM |
+| `0 0 * * 0` | Sunday at midnight |
+| `0 0 1 * *` | First of month at midnight |
+| `*/30 * * * *` | Every 30 minutes |
+| `0 9,17 * * *` | At 9 AM and 5 PM |
+
+### Special Characters
+
+| Character | Meaning |
+|-----------|---------|
+| `*` | Any value |
+| `,` | List separator (e.g., `1,15`) |
+| `-` | Range (e.g., `1-5`) |
+| `/` | Step values (e.g., `*/15`) |
+
+---
+
+## Managing Jobs {#list-jobs}
+
+### List All Jobs
+
+```bash
+docker-compose exec php php bin/console app:cron:list
+```
+
+Output:
+```
++----+------------------+-------------+--------+-------------+---------------------+
+| ID | Name             | Expression  | Active | Last Status | Last Run            |
++----+------------------+-------------+--------+-------------+---------------------+
+| 1  | Nightly Smoke    | 0 2 * * *   | Yes    | success     | 2025-01-15 02:00:05 |
+| 2  | Weekly Full      | 0 0 * * 0   | Yes    | failed      | 2025-01-14 00:00:03 |
+| 3  | Hourly Quick     | 0 * * * *   | No     | never       | -                   |
++----+------------------+-------------+--------+-------------+---------------------+
+```
+
+### Filter Active Only
+
+```bash
+docker-compose exec php php bin/console app:cron:list --active-only
+```
+
+---
+
+## Manual Execution {#manual-run}
+
+Trigger a scheduled job immediately:
+
+### By Job ID
+
+```bash
+docker-compose exec php php bin/console app:cron:run 1
+```
+
+### Wait for Completion
+
+```bash
+docker-compose exec php php bin/console app:cron:run 1 --sync
+```
+
+Output:
+```
+Executing job #1: Nightly Smoke
+Command: app:test:run mftf staging --filter=SmokeTestGroup
+Status: success
+Duration: 5m 23s
+Output: Test run #42 completed. 15 passed, 0 failed.
+```
+
+---
+
+## System Integration {#system-install}
+
+### Docker (Automatic)
+
+In Docker environment, the `matre_scheduler` container handles all scheduling automatically:
+
+```yaml
+# docker-compose.yml
+scheduler:
+  command: php bin/console messenger:consume scheduler_cron --time-limit=60 -vv
+  restart: unless-stopped
+```
+
+**No additional setup required** - scheduler runs continuously.
+
+### Manual Installation (Non-Docker)
+
+For non-Docker deployments, install to system crontab:
+
+#### Preview Entry
+
+```bash
+php bin/console app:cron:install --show-only
+```
+
+Output:
+```
+* * * * * cd /path/to/matre && php bin/console messenger:consume scheduler_cron --time-limit=55 >> var/log/scheduler.log 2>&1
+```
+
+#### Install to Crontab
+
+```bash
+php bin/console app:cron:install
+```
+
+#### Remove from Crontab
+
+```bash
+php bin/console app:cron:remove
+```
+
+---
+
+## Architecture
+
+### How Scheduling Works
+
+1. **CronJob entity** stores job configuration in database
+2. **CronJobScheduleProvider** reads active jobs on worker start
+3. **Symfony Scheduler** dispatches `CronJobMessage` at scheduled times
+4. **CronJobMessageHandler** executes the command
+5. Status and output stored back to CronJob entity
+
+### Locking Mechanism
+
+- Only one instance of a job can run at a time
+- Lock TTL: 1 hour (auto-releases on crash)
+- Status shows `locked` if already running
+- Prevents duplicate executions
+
+### Schedule Updates
+
+- Changes take effect within ~60 seconds
+- Worker restarts automatically pick up new schedule
+- No manual restart required
+
+---
+
+## Job Statuses
+
+| Status | Description |
+|--------|-------------|
+| `success` | Last execution completed successfully |
+| `failed` | Last execution encountered an error |
+| `running` | Currently executing |
+| `locked` | Another instance is running |
+| `never` | Job has never been executed |
+
+---
+
+## Viewing Job Output
+
+Job output is stored in the database. View via Admin UI:
+
+1. Navigate to **Cron Jobs**
+2. Click on job to view details
+3. **Last Output** shows execution log
+
+Or via database:
+```bash
+docker-compose exec db mysql -umatre -pmatre -e \
+  "SELECT name, last_status, last_output FROM matre.cron_job WHERE id = 1;"
+```
+
+---
+
+## Troubleshooting
+
+See [Troubleshooting Guide](troubleshooting.md#scheduling) for common issues:
+- Jobs not running
+- Stuck in locked status
+- Scheduler container issues

--- a/docs/operations/test-execution.md
+++ b/docs/operations/test-execution.md
@@ -1,0 +1,213 @@
+# Running Tests
+
+Complete guide for executing MFTF and Playwright tests.
+
+---
+
+## Prerequisites
+
+Before running tests, ensure:
+
+1. **Installation complete** - See [Installation Guide](../getting-started/installation.md)
+2. **Test environment configured** - See [Configuration](../getting-started/configuration.md#test-environment-configuration)
+3. **Health check passes:**
+   ```bash
+   docker-compose exec php php bin/console app:test:check-magento
+   ```
+
+---
+
+## Via Admin UI
+
+### Create Test Run
+
+1. Navigate to **Test Runs** in sidebar
+2. Click **New Test Run**
+3. Select **Environment** (configured in Admin → Test Environments)
+4. Choose **Type:**
+   - MFTF - Magento Functional Testing Framework
+   - Playwright - Modern E2E testing
+   - Both - Combined execution with merged reports
+5. Optional: Select **Suite** or enter **Filter** pattern
+6. Click **Start**
+
+### Monitor Progress
+
+Test runs display real-time status updates:
+
+```
+pending → preparing → cloning → running → reporting → completed
+```
+
+| Status | Description |
+|--------|-------------|
+| pending | Queued for execution |
+| preparing | Setting up test environment |
+| cloning | Fetching test module from repository |
+| running | Executing tests |
+| reporting | Generating Allure report |
+| completed | Finished successfully |
+| failed | Execution error occurred |
+| canceled | Manually stopped |
+
+### View Results
+
+- **Summary:** Pass/fail/skipped counts, total duration
+- **Details:** Individual test outcomes with error messages
+- **Screenshots:** Click thumbnails to view full failure screenshots
+- **Reports:** Link to Allure HTML report
+
+---
+
+## Via CLI {#cli}
+
+### Basic Usage
+
+```bash
+docker-compose exec php php bin/console app:test:run <type> <environment> [options]
+```
+
+**Arguments:**
+| Argument | Values | Description |
+|----------|--------|-------------|
+| type | `mftf`, `playwright`, `both` | Test framework to execute |
+| environment | environment code | Target environment (e.g., `staging`, `production`) |
+
+**Options:**
+| Option | Example | Description |
+|--------|---------|-------------|
+| `--filter` | `--filter=CheckoutTest` | Run specific test or group |
+| `--suite` | `--suite=smoke` | Use predefined test suite |
+| `--sync` | `--sync` | Wait for completion (blocking) |
+
+### Sync Execution (Blocking)
+
+Waits for test completion, shows results inline:
+
+```bash
+docker-compose exec php php bin/console app:test:run mftf staging --sync
+```
+
+Output:
+```
+Starting test run #42 on staging...
+Type: mftf
+Status: running
+
+✓ AdminLoginTest (2.3s)
+✓ StorefrontCategoryTest (5.1s)
+✗ StorefrontCheckoutTest (12.4s)
+  Error: Element not found: #place-order-button
+
+Completed: 2 passed, 1 failed
+Duration: 19.8s
+Report: http://localhost:5050/allure-docker-service/projects/run-42/reports/latest
+```
+
+### Async Execution
+
+Returns immediately, monitor via UI or API:
+
+```bash
+docker-compose exec php php bin/console app:test:run playwright production
+```
+
+Output:
+```
+Test run #43 created and queued.
+Monitor at: http://localhost:8089/admin/test-runs/43
+```
+
+### Examples
+
+```bash
+# Run MFTF smoke tests on staging, wait for results
+docker-compose exec php php bin/console app:test:run mftf staging --filter=SmokeTestGroup --sync
+
+# Run all Playwright tests on production (async)
+docker-compose exec php php bin/console app:test:run playwright production
+
+# Run both frameworks with a specific suite
+docker-compose exec php php bin/console app:test:run both staging --suite=regression --sync
+
+# Run specific test by name pattern
+docker-compose exec php php bin/console app:test:run mftf staging --filter=AdminCreateProduct
+```
+
+---
+
+## Via API
+
+See [API Reference](api-reference.md#test-runs) for programmatic access:
+
+- `POST /api/test-runs` - Create new run
+- `GET /api/test-runs/{id}` - Get run details
+- `POST /api/test-runs/{id}/cancel` - Cancel running test
+- `POST /api/test-runs/{id}/retry` - Retry failed test
+
+---
+
+## Test Types
+
+| Type | Framework | Best For |
+|------|-----------|----------|
+| **MFTF** | Codeception + Selenium | Magento admin panel, checkout flows, complex Magento interactions |
+| **Playwright** | Node.js + Chromium | Fast E2E tests, modern JS-based testing, cross-browser |
+| **Both** | Combined | Full coverage, merged Allure reports |
+
+### MFTF Tests
+
+- Executed via Magento's Functional Testing Framework
+- Requires Selenium Grid (chrome-node)
+- Tests stored in `TEST_MODULE_REPO` under `Test/Mftf/`
+- Results parsed from `TESTS.xml`
+
+### Playwright Tests
+
+- Executed via npx playwright
+- Built-in browser (Chromium)
+- Tests stored in `TEST_MODULE_REPO` under `tests/`
+- Results parsed from JSON reporter output
+
+---
+
+## Execution Pipeline
+
+```
+┌─────────┐    ┌───────────┐    ┌─────────┐    ┌─────────┐    ┌───────────┐    ┌───────────┐
+│ pending │ → │ preparing │ → │ cloning │ → │ running │ → │ reporting │ → │ completed │
+└─────────┘    └───────────┘    └─────────┘    └─────────┘    └───────────┘    └───────────┘
+                    │               │             │               │
+                    ↓               ↓             ↓               ↓
+               Module prep    Git clone    MFTF/Playwright    Allure
+               validation     from repo    execution          generation
+```
+
+### Phase Details
+
+1. **Preparing** - Validate environment, check prerequisites
+2. **Cloning** - Clone test module from `TEST_MODULE_REPO` (or symlink if `DEV_MODULE_PATH` set)
+3. **Running** - Execute tests via MFTF or Playwright executor
+4. **Reporting** - Merge results, generate Allure HTML report
+5. **Completed/Failed** - Final status with results stored
+
+---
+
+## Environment Locking
+
+Only one test can run per environment at a time to prevent conflicts.
+
+If you see "Environment is locked":
+1. Wait for current test to complete
+2. Cancel the running test via Admin UI
+3. Check for stuck runs in scheduler
+
+---
+
+## Troubleshooting
+
+See [Troubleshooting Guide](troubleshooting.md#test-execution) for common issues:
+- Environment locked
+- Module clone failed
+- Selenium unreachable
+- Test timeout

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,385 @@
+# Troubleshooting
+
+Quick solutions organized by symptom.
+
+---
+
+## Test Execution {#test-execution}
+
+### "Environment is locked"
+
+**Cause:** Another test is running on the same environment.
+
+**Solutions:**
+1. Wait for current test to complete
+2. Cancel running test via Admin UI → Test Runs → Cancel
+3. Check for stuck jobs:
+   ```bash
+   docker-compose exec php php bin/console app:cron:list
+   ```
+
+### "Module clone failed"
+
+**Cause:** Git credentials or network issue.
+
+**Solutions:**
+1. Verify repository URL in `.env`:
+   ```bash
+   grep TEST_MODULE_REPO .env
+   ```
+2. Check credentials:
+   ```bash
+   grep -E "REPO_USERNAME|REPO_PASSWORD" .env
+   ```
+3. Test clone manually:
+   ```bash
+   docker-compose exec php git clone {TEST_MODULE_REPO}
+   ```
+4. Check network from container:
+   ```bash
+   docker-compose exec php ping github.com
+   ```
+
+### "Selenium unreachable"
+
+**Cause:** Selenium Grid not running or misconfigured.
+
+**Solutions:**
+1. Check grid status:
+   ```bash
+   curl http://localhost:4444/status
+   ```
+2. Restart Selenium services:
+   ```bash
+   docker-compose restart selenium-hub chrome-node
+   ```
+3. Check container logs:
+   ```bash
+   docker-compose logs selenium-hub
+   docker-compose logs chrome-node
+   ```
+
+### "Test timeout"
+
+**Cause:** Test exceeded time limit.
+
+**Solutions:**
+1. Check Selenium Grid load (too many concurrent sessions)
+2. Increase timeout in test configuration
+3. Review test for slow operations
+4. Check target Magento performance
+
+### "MFTF binary not found"
+
+**Cause:** Magento container not properly set up.
+
+**Solutions:**
+1. Verify Magento container running:
+   ```bash
+   docker-compose ps matre_magento
+   ```
+2. Check MFTF installation:
+   ```bash
+   docker-compose exec magento vendor/bin/mftf --version
+   ```
+3. Rebuild Magento container:
+   ```bash
+   docker-compose up -d --build matre_magento
+   ```
+
+---
+
+## Reports {#reports}
+
+### "Allure report not generated"
+
+**Cause:** Allure service issue or no test results.
+
+**Solutions:**
+1. Check Allure service:
+   ```bash
+   docker-compose logs allure
+   curl http://localhost:5050/allure-docker-service/version
+   ```
+2. Verify results exist:
+   ```bash
+   ls var/allure-results/run-{id}/
+   ```
+3. Restart Allure service:
+   ```bash
+   docker-compose restart allure
+   ```
+
+### "Report shows no data"
+
+**Cause:** Results not uploaded to Allure.
+
+**Solutions:**
+1. Check test execution completed successfully
+2. Verify result files generated:
+   ```bash
+   ls var/allure-results/run-{id}/*-result.json
+   ```
+3. Check test worker logs:
+   ```bash
+   docker-compose logs matre_test_worker | grep -i allure
+   ```
+
+### "Screenshots not loading"
+
+**Cause:** Artifact path or permissions issue.
+
+**Solutions:**
+1. Check artifacts exist:
+   ```bash
+   ls var/test-artifacts/{runId}/
+   ```
+2. Fix permissions:
+   ```bash
+   chmod -R 755 var/test-artifacts
+   ```
+3. Verify nginx can serve files (check nginx logs)
+
+### "Old reports still showing"
+
+**Cause:** Cleanup not running or failed.
+
+**Solutions:**
+1. Run cleanup manually:
+   ```bash
+   docker-compose exec php php bin/console app:test:cleanup --dry-run
+   docker-compose exec php php bin/console app:test:cleanup
+   ```
+2. Check cleanup job in cron list
+
+---
+
+## Scheduling {#scheduling}
+
+### "Scheduled job not running"
+
+**Cause:** Scheduler container or queue issue.
+
+**Solutions:**
+1. Check scheduler container:
+   ```bash
+   docker-compose ps matre_scheduler
+   docker-compose logs matre_scheduler
+   ```
+2. Restart scheduler:
+   ```bash
+   docker-compose restart matre_scheduler
+   ```
+3. Verify job is active:
+   ```bash
+   docker-compose exec php php bin/console app:cron:list --active-only
+   ```
+
+### "Job stuck in 'locked' status"
+
+**Cause:** Previous run didn't release lock (crash or timeout).
+
+**Solutions:**
+1. Wait for auto-expiry (1 hour TTL)
+2. Check if job is actually running:
+   ```bash
+   docker-compose exec php php bin/console app:cron:list
+   ```
+3. Manual database cleanup (last resort):
+   ```sql
+   UPDATE cron_job SET last_status = 'failed' WHERE last_status = 'locked';
+   ```
+
+### "Duplicate job executions"
+
+**Cause:** Multiple scheduler instances or locking failure.
+
+**Solutions:**
+1. Ensure only one scheduler container:
+   ```bash
+   docker-compose ps | grep scheduler
+   ```
+2. Check lock mechanism in logs
+
+---
+
+## Docker {#docker}
+
+### "Container restart loop"
+
+**Solutions:**
+1. Check logs for error:
+   ```bash
+   docker-compose logs {container}
+   ```
+2. Common fixes:
+   ```bash
+   docker-compose down
+   docker-compose up -d --build
+   ```
+3. Check for config errors in `.env`
+
+### "Port already in use"
+
+**Solutions:**
+1. Find process using port:
+   ```bash
+   lsof -i :8089
+   ```
+2. Kill process or change port in `docker-compose.yml`
+
+### "Volume permission denied"
+
+**Solutions:**
+1. Fix ownership:
+   ```bash
+   sudo chown -R $(id -u):$(id -g) var/
+   ```
+2. Or run container as current user
+
+### "Container not starting"
+
+**Solutions:**
+1. Check Docker daemon:
+   ```bash
+   docker info
+   ```
+2. Check available disk space:
+   ```bash
+   df -h
+   ```
+3. Prune unused resources:
+   ```bash
+   docker system prune
+   ```
+
+---
+
+## Database {#database}
+
+### "Migration failed"
+
+**Solutions:**
+1. Check migration status:
+   ```bash
+   docker-compose exec php php bin/console doctrine:migrations:status
+   ```
+2. See detailed error:
+   ```bash
+   docker-compose exec php php bin/console doctrine:migrations:migrate -vvv
+   ```
+3. Force specific version:
+   ```bash
+   docker-compose exec php php bin/console doctrine:migrations:execute --up {version}
+   ```
+
+### "Connection refused"
+
+**Solutions:**
+1. Check database container:
+   ```bash
+   docker-compose ps matre_db
+   ```
+2. Test connection:
+   ```bash
+   docker-compose exec db mysqladmin ping -umatre -pmatre
+   ```
+3. Verify credentials in `.env`
+
+### "Lock wait timeout"
+
+**Cause:** Long-running transaction blocking.
+
+**Solutions:**
+1. Identify blocking query:
+   ```sql
+   SHOW PROCESSLIST;
+   ```
+2. Kill blocking process:
+   ```sql
+   KILL {process_id};
+   ```
+
+---
+
+## Queue {#queue}
+
+### "Messages not processing"
+
+**Solutions:**
+1. Check worker container:
+   ```bash
+   docker-compose ps matre_test_worker
+   docker-compose logs matre_test_worker
+   ```
+2. Restart worker:
+   ```bash
+   docker-compose restart matre_test_worker
+   ```
+3. Check pending messages:
+   ```bash
+   docker-compose exec db mysql -umatre -pmatre -e \
+     "SELECT queue_name, COUNT(*) FROM matre.messenger_messages GROUP BY queue_name;"
+   ```
+
+### "Messages in failed queue"
+
+**Solutions:**
+1. View failed messages:
+   ```bash
+   docker-compose exec php php bin/console messenger:failed:show
+   ```
+2. Retry specific message:
+   ```bash
+   docker-compose exec php php bin/console messenger:failed:retry {id}
+   ```
+3. Retry all failed:
+   ```bash
+   docker-compose exec php php bin/console messenger:failed:retry --all
+   ```
+
+---
+
+## Diagnostic Commands
+
+Quick reference for troubleshooting:
+
+```bash
+# Overall service status
+docker-compose ps
+
+# Full system health check
+docker-compose exec php php bin/console app:test:check-magento
+
+# Container logs
+docker-compose logs -f {container}
+docker-compose logs --tail=100 {container}
+
+# Queue status
+docker-compose exec db mysql -umatre -pmatre -e \
+  "SELECT queue_name, COUNT(*) FROM matre.messenger_messages GROUP BY queue_name;"
+
+# Check running tests
+docker-compose exec db mysql -umatre -pmatre -e \
+  "SELECT id, status, type FROM matre.test_run WHERE status IN ('pending', 'running');"
+
+# View cron jobs
+docker-compose exec php php bin/console app:cron:list
+
+# Clear Symfony cache
+docker-compose exec php php bin/console cache:clear
+
+# Rebuild containers
+docker-compose down && docker-compose up -d --build
+```
+
+---
+
+## Getting Help
+
+If these solutions don't resolve your issue:
+
+1. Check container logs for detailed error messages
+2. Enable debug mode: Set `APP_DEBUG=1` in `.env`
+3. Review [Installation Guide](../getting-started/installation.md) for setup issues
+4. Review [Configuration](../getting-started/configuration.md) for settings

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -1,0 +1,284 @@
+# Unit Tests
+
+> **Note:** This guide covers PHP unit/functional testing with PHPUnit.
+> For running MFTF and Playwright E2E tests, see [Test Execution Guide](../operations/test-execution.md).
+
+This guide covers testing practices for MATRE using PHPUnit.
+
+## Running Tests
+
+### Docker (Recommended)
+```bash
+# All tests
+docker-compose exec php bin/phpunit
+
+# Specific test file
+docker-compose exec php bin/phpunit tests/Unit/Entity/UserTest.php
+
+# Specific test method
+docker-compose exec php bin/phpunit --filter testConstructorSetsDefaults
+
+# With coverage
+docker-compose exec php bash -c "XDEBUG_MODE=coverage bin/phpunit --coverage-html var/coverage"
+```
+
+### Local
+```bash
+# All tests
+bin/phpunit
+
+# With coverage
+XDEBUG_MODE=coverage bin/phpunit --coverage-html var/coverage
+```
+
+---
+
+## Test Directory Structure
+
+```
+tests/
+├── Unit/
+│   ├── Entity/           # Entity unit tests
+│   ├── Service/          # Service unit tests
+│   └── Form/             # Form type tests
+├── Functional/
+│   └── Controller/       # Controller tests
+└── bootstrap.php         # Test bootstrap
+```
+
+---
+
+## Entity Tests
+
+Test entity behavior in `tests/Unit/Entity/`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Category;
+use PHPUnit\Framework\TestCase;
+
+class CategoryTest extends TestCase
+{
+    public function testConstructorSetsDefaults(): void
+    {
+        $category = new Category();
+
+        $this->assertNull($category->getId());
+        $this->assertTrue($category->getIsActive());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $category->getCreatedAt());
+        $this->assertNull($category->getUpdatedAt());
+    }
+
+    public function testSetName(): void
+    {
+        $category = new Category();
+        $result = $category->setName('Test Category');
+
+        $this->assertSame('Test Category', $category->getName());
+        $this->assertSame($category, $result); // Fluent interface
+    }
+
+    public function testSetSlug(): void
+    {
+        $category = new Category();
+        $category->setSlug('test-category');
+
+        $this->assertSame('test-category', $category->getSlug());
+    }
+
+    public function testToggleActive(): void
+    {
+        $category = new Category();
+
+        $this->assertTrue($category->getIsActive());
+
+        $category->setIsActive(false);
+        $this->assertFalse($category->getIsActive());
+
+        $category->setIsActive(true);
+        $this->assertTrue($category->getIsActive());
+    }
+
+    public function testToString(): void
+    {
+        $category = new Category();
+        $category->setName('My Category');
+
+        $this->assertSame('My Category', (string) $category);
+    }
+}
+```
+
+---
+
+## Controller Tests
+
+Test controllers in `tests/Functional/Controller/`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller;
+
+use App\Repository\UserRepository;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class AdminDashboardControllerTest extends WebTestCase
+{
+    public function testDashboardRequiresLogin(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/admin/dashboard');
+
+        $this->assertResponseRedirects('/login');
+    }
+
+    public function testDashboardAccessibleWhenLoggedIn(): void
+    {
+        $client = static::createClient();
+
+        // Get admin user
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $adminUser = $userRepository->findOneBy(['username' => 'admin']);
+
+        // Login
+        $client->loginUser($adminUser);
+
+        $client->request('GET', '/admin/dashboard');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Dashboard');
+    }
+}
+```
+
+---
+
+## Repository Tests
+
+Test repositories with database:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Repository;
+
+use App\Entity\Category;
+use App\Repository\CategoryRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class CategoryRepositoryTest extends KernelTestCase
+{
+    private CategoryRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->repository = static::getContainer()->get(CategoryRepository::class);
+    }
+
+    public function testFindActive(): void
+    {
+        $categories = $this->repository->findActive();
+
+        foreach ($categories as $category) {
+            $this->assertTrue($category->getIsActive());
+        }
+    }
+}
+```
+
+---
+
+## Mocking
+
+Use PHPUnit mocks for isolated unit tests:
+
+```php
+public function testServiceWithMockedDependency(): void
+{
+    $repository = $this->createMock(CategoryRepository::class);
+    $repository->expects($this->once())
+        ->method('findAll')
+        ->willReturn([new Category()]);
+
+    $service = new CategoryService($repository);
+    $result = $service->getAllCategories();
+
+    $this->assertCount(1, $result);
+}
+```
+
+---
+
+## Test Database
+
+Configure a test database in `.env.test`:
+
+```dotenv
+DATABASE_URL="mysql://root:password@127.0.0.1:3306/matre_test?serverVersion=8.0"
+```
+
+Setup test database:
+```bash
+# Create test database
+php bin/console doctrine:database:create --env=test
+
+# Run migrations
+php bin/console doctrine:migrations:migrate --env=test --no-interaction
+
+# Load fixtures
+php bin/console doctrine:fixtures:load --env=test --no-interaction
+```
+
+---
+
+## Code Quality
+
+### PHPStan
+```bash
+docker-compose exec php vendor/bin/phpstan analyse
+```
+
+### PHP-CS-Fixer
+```bash
+# Check style
+docker-compose exec php vendor/bin/php-cs-fixer fix --dry-run --diff
+
+# Fix style
+docker-compose exec php vendor/bin/php-cs-fixer fix
+```
+
+---
+
+## CI Integration
+
+Tests run automatically in GitHub Actions (`.github/workflows/symfony-ci.yml`):
+
+1. **code-quality** - PHPStan, PHP-CS-Fixer
+2. **phpunit-tests** - All PHPUnit tests
+3. **security-audit** - Composer audit
+4. **doctrine-validation** - Schema validation
+5. **lint** - PHP, Twig, YAML linting
+
+---
+
+## Checklist
+
+When writing tests:
+
+1. [ ] Test entity constructors and defaults
+2. [ ] Test getters/setters with fluent interface
+3. [ ] Test relationships (add/remove)
+4. [ ] Test controller routes require auth
+5. [ ] Test form validation
+6. [ ] Run full test suite before commit


### PR DESCRIPTION
## Summary

Adds comprehensive operations documentation with SOLID principles (single responsibility per doc, zero duplication).

### New Documentation (`docs/operations/`)

| File | Purpose |
|------|---------|
| `cli-reference.md` | Command index with links to detailed guides |
| `test-execution.md` | Full workflow for running MFTF/Playwright tests (UI, CLI, API) |
| `allure-reports.md` | Report viewing, retention policy, cleanup procedures |
| `monitoring.md` | Health checks, diagnostics, queue monitoring |
| `scheduling.md` | Cron setup, job management, system integration |
| `api-reference.md` | REST API documentation with examples |
| `troubleshooting.md` | Symptom-based problem resolution |

### Updates to Existing Files

- Rename `testing.md` → `unit-tests.md` with note linking to test-execution guide
- Reorganize README.md Documentation section with Operations subsection
- Add `.claude` to `.gitignore`

## Test plan

- [ ] Verify all markdown links work correctly
- [ ] Verify CLI commands documented match actual commands
- [ ] Verify API endpoints documented match actual implementation