### PR TITLE
Add assets/vendor and dev module to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,12 @@
 /public/bundles/
 /var/
 /vendor/
+/assets/vendor/
 ###< symfony/framework-bundle ###
+
+###> Local Development ###
+/abb-custom-mftf/
+###< Local Development ###
 
 ###> phpunit/phpunit ###
 /phpunit.xml


### PR DESCRIPTION
## Summary
- Ignore `/assets/vendor/` - Symfony ImportMap vendor files (regeneratable via `bin/console importmap:install`)
- Ignore `/abb-custom-mftf/` - Local development module directory for DEV_MODULE_PATH

## Test plan
- [ ] Verify untracked files no longer appear in git status
- [ ] Verify `importmap:install` regenerates assets/vendor when needed