### PR TITLE
Fix login page missing styles

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,2 @@
+import './styles/tailwind.css';
+import './styles/app.css';

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1,0 +1,100 @@
+:root {
+    --rs-bg-start: #f8fafc;
+    --rs-bg-end: #dbeafe;
+    --rs-card-bg: #ffffff;
+    --rs-card-shadow: 0 10px 20px rgba(0, 0, 0, 0.06);
+    --rs-text-muted: #64748b;
+    --rs-primary-blue: #3b82f6;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+body.app-shell {
+    min-height: 100vh;
+    margin: 0;
+    font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    background: radial-gradient(circle at top, var(--rs-bg-end), var(--rs-bg-start));
+    color: #0f172a;
+}
+
+.auth-hero {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1rem;
+}
+
+.auth-card {
+    width: min(420px, 100%);
+    background: var(--rs-card-bg);
+    border-radius: 1rem;
+    padding: 2.5rem;
+    box-shadow: var(--rs-card-shadow);
+}
+
+.auth-logo {
+    width: 64px;
+    height: 64px;
+    border-radius: 18px;
+    background: var(--rs-primary-blue);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+}
+
+.auth-title {
+    font-size: 1.875rem;
+    font-weight: 600;
+}
+
+.auth-subtitle {
+    color: var(--rs-text-muted);
+    margin-bottom: 2rem;
+}
+
+.form-control,
+.form-check-input {
+    border-radius: 0.75rem;
+    border-color: #e2e8f0;
+    padding: 0.85rem 1rem;
+    font-size: 0.95rem;
+}
+
+.form-control:focus {
+    border-color: var(--rs-primary-blue);
+    box-shadow: 0 0 0 0.2rem rgba(59, 130, 246, 0.15);
+}
+
+.auth-cta {
+    background: var(--rs-primary-blue);
+    border: none;
+    font-weight: 600;
+    padding: 0.95rem;
+    border-radius: 0.85rem;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.auth-cta:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 30px rgba(37, 99, 235, 0.3);
+}
+
+.auth-footnote {
+    color: var(--rs-text-muted);
+}
+
+.remember-me {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    cursor: pointer;
+}

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -17,6 +17,7 @@ export default defineConfig({
     outDir: 'public/build',
     rollupOptions: {
       input: {
+        app: './assets/app.js',
         admin: './assets/admin.js',
         admin_vue: './assets/vue/admin-dashboard-app.js',
         admin_users_vue: './assets/vue/admin-users-app.js',


### PR DESCRIPTION
## Summary
- Create `assets/app.js` entry point importing Tailwind and app.css
- Add `assets/styles/app.css` with auth page styles (auth-hero, auth-card, auth-logo, etc.)
- Add `app` entry to `vite.config.mjs` rollupOptions.input

## Problem
Login page at `/login` had no styles - the base template referenced `vite_entry_link_tags('app')` but no `app` entry existed in Vite config.

## Test plan
- [ ] Visit https://matre.local/login
- [ ] Verify styled login card with gradient background appears
- [ ] Run `npm run build` and confirm app CSS is generated