### PR TITLE
Resolve ActionGroup env vars to actual test names

### DIFF
--- a/migrations/Version20251217050838.php
+++ b/migrations/Version20251217050838.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20251217050838 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Expand usedInTests column to TEXT for ActionGroup resolution';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE matre_global_env_variables CHANGE used_in_tests used_in_tests LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE matre_global_env_variables CHANGE used_in_tests used_in_tests VARCHAR(500) DEFAULT NULL');
+    }
+}

--- a/src/Entity/GlobalEnvVariable.php
+++ b/src/Entity/GlobalEnvVariable.php
@@ -43,7 +43,7 @@ class GlobalEnvVariable
     #[Assert\NotBlank(message: 'Value cannot be blank.')]
     private string $value;
 
-    #[ORM\Column(type: Types::STRING, length: 500, nullable: true)]
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $usedInTests = null;
 
     #[ORM\Column(type: Types::STRING, length: 500, nullable: true)]


### PR DESCRIPTION
## Summary
- EnvVariableAnalyzerService now traces ActionGroup → Test relationships
- Env vars used in ActionGroups (like `MAGENTO_ADMIN_CHAMPION_PASSWORD` in `LoginAsChampionAdminActionGroup`) now show the tests that use those ActionGroups in the `usedInTests` field
- Expanded `usedInTests` column from VARCHAR(500) to TEXT to accommodate many test references

## Changes
- `parseActionGroupEnvVars()` - extracts env vars from ActionGroup XML files
- `parseTestActionGroupRefs()` - maps tests to their ActionGroup references
- Modified `analyzeTestUsage()` to resolve transitive dependencies
- Migration to expand column type

## Test plan
- [x] Run `app:env:import stage-us --overwrite`
- [x] Verify `MAGENTO_ADMIN_CHAMPION_PASSWORD` shows `MOEC7223CUS` in usedInTests