### PR TITLE
Fix checkbox margin - add gap between input and label

### DIFF
--- a/assets/styles/admin.css
+++ b/assets/styles/admin.css
@@ -647,6 +647,7 @@ small.form-text,
 .form-check {
     display: flex;
     align-items: flex-start;
+    gap: 8px;
     margin-bottom: var(--space-sm);
     padding-left: 0;
 }


### PR DESCRIPTION
## Summary
- Add `gap: 8px` to `.form-check` flex container for consistent spacing between checkbox inputs and labels

## Test plan
- [ ] Verify checkboxes on Settings page have proper spacing
- [ ] Check other forms with checkboxes for consistent styling