### PR TITLE
Enable nginx port 8089 by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,8 @@ services:
   nginx:
     image: nginx:1.25-alpine
     container_name: matre_nginx
-    # ports:
-    #   - "8089:80" # Disabled - Traefik handles HTTPS
+    ports:
+      - "8089:80"
     volumes:
       - .:/app:ro
       - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
@@ -337,4 +337,4 @@ networks:
   matre_network:
     driver: bridge
   traefik:
-    external: true
+    driver: bridge


### PR DESCRIPTION
## Summary

- Enable nginx port 8089 for direct HTTP access without Traefik
- Change traefik network from external to internal (auto-created)

## Why

Users installing MATRE without Traefik couldn't access the app:
- nginx port was commented out
- traefik network required external creation

Now works out-of-box at `http://localhost:8089`

## Changes

| File | Change |
|------|--------|
| docker-compose.yml | Enable `ports: - "8089:80"` |
| docker-compose.yml | Change `traefik: external: true` → `driver: bridge` |

## Testing

✅ Verified app loads at `http://matre.local:8089`