### PR TITLE
Refactor allure_cleanup.py v2: multi-env batch ops, suite filtering

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 
 ## allure_cleanup.py
 
-Completely remove test results from Allure reports by test ID pattern.
+Remove test results from Allure reports with advanced filtering. Supports multi-environment batch operations and suite-based filtering.
 
 ### What It Removes
 
@@ -11,69 +11,85 @@ Completely remove test results from Allure reports by test ID pattern.
 3. **Suites entry** (`data/suites.json`)
 4. **History entry** (`history/history.json`)
 
-### Usage
+### Environment Shortcuts
+
+| Shortcut | Environments |
+|----------|--------------|
+| `all` | stage-us, stage-es, preprod-us, preprod-es |
+| `us` | stage-us, preprod-us |
+| `es` | stage-es, preprod-es |
+| `stage` | stage-us, stage-es |
+| `preprod` | preprod-us, preprod-es |
+
+### Usage Examples
 
 ```bash
-# Dry run (preview what will be removed):
-python allure_cleanup.py --ssh abb --path /path/to/allure-report --test-id "TEST-123" --dry-run
+# Remove test from all environments
+python3 scripts/allure_cleanup.py -t MOEC8899ES --sudo
 
-# Execute cleanup with sudo (required for permission issues):
-python allure_cleanup.py --ssh abb --path /path/to/allure-report --test-id "TEST-123" --sudo
+# Remove from specific suite only (e.g., group1)
+python3 scripts/allure_cleanup.py -t MOEC2417 --in-suite group1 --sudo
 
-# Multiple tests:
-python allure_cleanup.py --ssh abb --path /path/to/report --test-id "TEST-123" --test-id "TEST-456" --sudo
+# Remove from ES environments only
+python3 scripts/allure_cleanup.py -t MOEC3758 --env es --sudo
 
-# Local execution (no SSH):
-python allure_cleanup.py --path /local/path/to/allure-report --test-id "TEST-123"
+# Remove from group1 on US environments only
+python3 scripts/allure_cleanup.py -t MOEC-5173 --in-suite group1 --env us --sudo
+
+# Keep entries in functional\us suite (remove from everywhere else)
+python3 scripts/allure_cleanup.py -t MOEC5317 --not-in-suite us --sudo
+
+# Multiple test IDs
+python3 scripts/allure_cleanup.py -t MOEC3758 -t MOEC11676 --env es --sudo
+
+# Dry run (preview changes)
+python3 scripts/allure_cleanup.py -t MOEC2417 --in-suite group1 --dry-run
 ```
 
 ### Options
 
-| Option | Short | Required | Description |
-|--------|-------|----------|-------------|
-| `--path` | `-p` | Yes | Path to allure report directory |
-| `--test-id` | `-t` | Yes | Test ID pattern (can use multiple times) |
-| `--ssh` | `-s` | No | SSH host alias from ~/.ssh/config |
-| `--dry-run` | `-n` | No | Preview changes without modifying files |
-| `--sudo` | | No | Use sudo for file operations |
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--test-id` | `-t` | (required) | Test ID pattern (can use multiple times) |
+| `--env` | `-e` | `all` | Environment shortcut or comma-separated list |
+| `--in-suite` | | | Only remove from these suites (can use multiple times) |
+| `--not-in-suite` | | | Do not remove from these suites (can use multiple times) |
+| `--ssh` | `-s` | `abb` | SSH host alias (use `local` for local execution) |
+| `--base-path` | `-p` | `/home/ubuntu/ABBTests/src/pub/allure-report-{env}` | Base path template |
+| `--dry-run` | `-n` | | Preview changes without modifying files |
+| `--sudo` | | | Use sudo for file operations |
 
 ### Example Output
 
 ```
 Allure History Cleanup
 ==================================================
-Report path: /home/ubuntu/ABBTests/src/pub/allure-report-stage-us
+Test IDs: MOEC2417
+Environments: stage-us, stage-es, preprod-us, preprod-es
+Base path: /home/ubuntu/ABBTests/src/pub/allure-report-{env}
+In suites: group1
 SSH host: abb
-Test IDs: MOEC-2609US
 Dry run: False
 Use sudo: True
 
-Step 1: Searching for tests in report...
-  Found 1 matching test(s):
-    - MOEC-2609US: UAT Product Details Page
-      UID: 5cbfffa5c14812ad, Status: broken, Retries: 24
+stage-us: Removed 236 entries
+  - MOEC2417: Test for LV Drives configurators - Edit
+    Suite: Magento\FunctionalTestingFramework.functional\group1
+  ... and 231 more
 
-Step 2: Finding history IDs...
-  Found 1 history ID(s):
-    - 171e13759e7d9b98c19bda7a48a75381
+stage-es: Removed 234 entries
+  - MOEC2417: Test for LV Drives configurators - Edit
+    Suite: Magento\FunctionalTestingFramework.functional\group1
+  ... and 229 more
 
-Step 3: Removing test-case files...
-  Removed: .../data/test-cases/5cbfffa5c14812ad.json
-
-Step 4: Removing from behaviors.json...
-  Removed 1 entries from behaviors.json (backup created)
-
-Step 5: Removing from suites.json...
-  Removed 1 entries from suites.json (backup created)
-
-Step 6: Removing from history.json...
-
-Done! Complete cleanup finished
+==================================================
+Total: 580 entries removed across 4 environment(s)
 ```
 
 ### Recovery
 
 Backups created with `.bak` extension. To restore:
+
 ```bash
 ssh abb "sudo cp /path/to/report/data/behaviors.json.bak /path/to/report/data/behaviors.json"
 ssh abb "sudo cp /path/to/report/data/suites.json.bak /path/to/report/data/suites.json"


### PR DESCRIPTION
## Summary
- Add environment shortcuts (all, us, es, stage, preprod) for batch operations
- Add --in-suite/--not-in-suite filters for targeted cleanup by suite
- Generate and execute cleanup script directly on remote host (faster than SSH per-command)
- Update README with comprehensive usage examples

## Test plan
- [x] Dry run tested: `python3 scripts/allure_cleanup.py -t MOEC2417 --in-suite group1 --env stage-us --dry-run --sudo`
- [x] Script help verified: `python3 scripts/allure_cleanup.py --help`