### PR TITLE
Upgrade Magento to 2.4.8 with PHP 8.3 and OpenSearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -266,13 +266,13 @@ services:
       DB_NAME: magento
       DB_USER: magento
       DB_PASS: magento
-      ES_HOST: magento-elasticsearch
+      OPENSEARCH_HOST: magento-opensearch
       REDIS_HOST: magento-redis
       SELENIUM_HOST: selenium-hub
       SELENIUM_PORT: 4444
     depends_on:
       - magento-db
-      - magento-elasticsearch
+      - magento-opensearch
       - magento-redis
       - selenium-hub
     networks:
@@ -292,16 +292,17 @@ services:
     networks:
       - matre_network
 
-  # Magento Elasticsearch
-  magento-elasticsearch:
-    image: elasticsearch:7.17.14
-    container_name: matre_magento_es
+  # Magento OpenSearch (required for Magento 2.4.8+)
+  magento-opensearch:
+    image: opensearchproject/opensearch:2.14.0
+    container_name: matre_magento_opensearch
     environment:
       - discovery.type=single-node
-      - xpack.security.enabled=false
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - DISABLE_SECURITY_PLUGIN=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=Admin123!
     volumes:
-      - matre_magento_es_data:/usr/share/elasticsearch/data
+      - matre_magento_opensearch_data:/usr/share/opensearch/data
     networks:
       - matre_network
 
@@ -356,7 +357,7 @@ volumes:
   matre_vendor:
   matre_magento_code:
   matre_magento_db_data:
-  matre_magento_es_data:
+  matre_magento_opensearch_data:
   traefik_certs:
 
 networks:

--- a/docker/magento/Dockerfile
+++ b/docker/magento/Dockerfile
@@ -1,7 +1,7 @@
 # Magento 2 Docker Container for ATR
-# PHP 8.2 for Magento 2.4.6 compatibility (MFTF binary execution)
+# PHP 8.3 for Magento 2.4.8 compatibility (MFTF 5.x)
 
-FROM php:8.2-fpm-alpine
+FROM php:8.3-fpm-alpine
 
 # Install system dependencies
 RUN apk add --no-cache \
@@ -23,6 +23,7 @@ RUN apk add --no-cache \
     linux-headers
 
 # Configure and install PHP extensions
+# ftp extension required for Magento 2.4.8+
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) \
         gd \
@@ -34,7 +35,8 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
         soap \
         bcmath \
         sockets \
-        opcache
+        opcache \
+        ftp
 
 # Install Composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer

--- a/docker/magento/install.sh
+++ b/docker/magento/install.sh
@@ -56,14 +56,14 @@ for i in {1..30}; do
     sleep 5
 done
 
-# Wait for Elasticsearch
-echo "Waiting for Elasticsearch..."
+# Wait for OpenSearch
+echo "Waiting for OpenSearch..."
 for i in {1..30}; do
-    if curl -s "http://${ES_HOST:-magento-elasticsearch}:9200" > /dev/null 2>&1; then
-        echo "Elasticsearch ready."
+    if curl -s "http://${OPENSEARCH_HOST:-magento-opensearch}:9200" > /dev/null 2>&1; then
+        echo "OpenSearch ready."
         break
     fi
-    echo "Elasticsearch not ready, waiting... ($i/30)"
+    echo "OpenSearch not ready, waiting... ($i/30)"
     sleep 5
 done
 
@@ -132,9 +132,9 @@ bin/magento setup:install \
     --currency="USD" \
     --timezone="America/New_York" \
     --use-rewrites="1" \
-    --search-engine="elasticsearch7" \
-    --elasticsearch-host="${ES_HOST:-magento-elasticsearch}" \
-    --elasticsearch-port="9200" \
+    --search-engine="opensearch" \
+    --opensearch-host="${OPENSEARCH_HOST:-magento-opensearch}" \
+    --opensearch-port="9200" \
     --session-save="redis" \
     --session-save-redis-host="${REDIS_HOST:-magento-redis}" \
     --cache-backend="redis" \


### PR DESCRIPTION
## Summary
- Upgrade Magento from 2.4.7 to 2.4.8
- Upgrade PHP from 8.2 to 8.3 in Magento container
- Switch from Elasticsearch 7 to OpenSearch 2.14 (ES7 dropped in 2.4.8)
- Add FTP PHP extension required for 2.4.8+
- MFTF upgraded from 4.x to 5.0.6

## Test plan
- [x] Magento 2.4.8 installs successfully
- [x] MFTF 5.0.6 works correctly
- [x] Test run #138 (MOEC5157) passed on stage-us

## Files Changed
- `docker-compose.yml` - OpenSearch service config
- `docker/magento/Dockerfile` - PHP 8.3, ftp extension
- `docker/magento/install.sh` - OpenSearch parameters