### PR TITLE
Add source results cleanup to allure_cleanup.py for permanent test deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,9 @@ docker-compose logs -f matre_test_worker
 - [Architecture Overview](docs/development/architecture.md)
 - [Entities](docs/development/entities.md)
 - [Admin CRUD](docs/development/admin-crud.md)
+- [Forms](docs/development/forms.md) - Form handling patterns
+- [Vue Islands](docs/development/vue-islands.md) - Vue 3 component pattern
+- [Dev Mode](docs/development/dev-mode.md) - Local module development
 - [Unit Tests](docs/testing/unit-tests.md) - PHPUnit testing
 
 ### Deployment

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,14 +2,18 @@
 
 ## allure_cleanup.py
 
-Remove test results from Allure reports with advanced filtering. Supports multi-environment batch operations and suite-based filtering.
+Remove test results from Allure reports **permanently** with advanced filtering. Supports multi-environment batch operations and suite-based filtering.
 
 ### What It Removes
 
+**From Generated Report** (`allure-report-{env}/`):
 1. **Test-case file** (`data/test-cases/{uid}.json`)
 2. **Behaviors entry** (`data/behaviors.json`)
 3. **Suites entry** (`data/suites.json`)
 4. **History entry** (`history/history.json`)
+
+**From Source Results** (`allure-results-{env}/`):
+5. **Testsuite XML files** (`{uuid}-testsuite.xml`) - **Prevents re-appearance after report regeneration**
 
 ### Environment Shortcuts
 
@@ -72,18 +76,22 @@ SSH host: abb
 Dry run: False
 Use sudo: True
 
-stage-us: Removed 236 entries
+stage-us: Removed 236 report entries, 236 source files
   - MOEC2417: Test for LV Drives configurators - Edit
     Suite: Magento\FunctionalTestingFramework.functional\group1
-  ... and 231 more
+  ... and 231 more report entries
+  📁 abc123-testsuite.xml (MOEC2417)
+  ... and 231 more source files
 
-stage-es: Removed 234 entries
+stage-es: Removed 234 report entries, 234 source files
   - MOEC2417: Test for LV Drives configurators - Edit
     Suite: Magento\FunctionalTestingFramework.functional\group1
-  ... and 229 more
+  ... and 229 more report entries
+  📁 def456-testsuite.xml (MOEC2417)
+  ... and 229 more source files
 
 ==================================================
-Total: 580 entries removed across 4 environment(s)
+Total: 470 report entries + 470 source files removed across 4 environment(s)
 ```
 
 ### Recovery


### PR DESCRIPTION
## Summary
- Add `cleanup_source_results()` to delete XML testsuite files from `allure-results-{env}/` folder
- Apply suite filter to both report and source cleanup (ensures consistency)
- Update `print_results()` to show source files removed with suite info
- Update scripts/README.md with new behavior and output format
- Add missing doc links to main README

## Why
Previously, `allure_cleanup.py` only removed tests from generated reports (`allure-report-{env}/`), but source results in `allure-results-{env}/` remained. When the next test run regenerated reports, deleted tests would reappear.

Now cleanup removes from **both** locations, making deletions permanent.

## Test plan
- [x] Dry-run tested with suite filtering
- [x] Executed cleanup on all 4 environments (36,960 report + 11,184 source files removed)
- [x] Verified wrong groups removed, correct `us`/`es` groups preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)