### PR TITLE
Fix duration formatting inconsistency in test results table

### DIFF
--- a/src/Controller/Admin/TestRunController.php
+++ b/src/Controller/Admin/TestRunController.php
@@ -303,6 +303,7 @@ class TestRunController extends AbstractController
                 'testName' => $result->getTestName(),
                 'status' => $result->getStatus(),
                 'duration' => $result->getDuration(),
+                'durationFormatted' => $result->getDurationFormatted(),
                 'errorMessage' => $result->getErrorMessage(),
                 'hasScreenshot' => $result->getScreenshotPath() !== null,
                 'hasOutputFile' => $result->getOutputFilePath() !== null,

--- a/templates/admin/test_run/show.html.twig
+++ b/templates/admin/test_run/show.html.twig
@@ -180,7 +180,7 @@
                                     {{ result.status|upper }}
                                 </span>
                             </td>
-                            <td>{{ result.duration ? (result.duration ~ 's') : '-' }}</td>
+                            <td>{{ result.durationFormatted }}</td>
                             <td>
                                 <div class="btn-group btn-group-sm">
                                     <button type="button"
@@ -522,7 +522,7 @@
 
             // Duration cell (safe: textContent)
             const durationTd = document.createElement('td');
-            durationTd.textContent = result.duration ? result.duration + 's' : '-';
+            durationTd.textContent = result.durationFormatted || '-';
             tr.appendChild(durationTd);
 
             // Actions cell (safe: DOM construction)


### PR DESCRIPTION
## Summary
- Use `getDurationFormatted()` instead of raw seconds in Twig template
- Update live JS to use `durationFormatted` from API response
- Add `durationFormatted` field to live output API endpoint

Shows "13m 12s" format consistently instead of raw "791.751s"

## Test plan
- [ ] View test run detail page with completed results
- [ ] Verify duration shows formatted time (e.g., "13m 12s") instead of raw seconds
- [ ] Run a test and verify live results also show formatted duration