### PR TITLE
Copy module _data fixtures to central MFTF dir

### DIFF
--- a/src/Service/MftfExecutorService.php
+++ b/src/Service/MftfExecutorService.php
@@ -224,8 +224,11 @@ class MftfExecutorService
         $parts[] = sprintf('rm -rf %s', escapeshellarg($modulePath)); // Remove existing
         $parts[] = sprintf('ln -sf %s %s', escapeshellarg($mountedModulePath), escapeshellarg($modulePath));
 
-        // Change to acceptance test directory
+        // Copy module _data files (CSV fixtures etc.) to central MFTF _data directory
         $acceptanceDir = $this->magentoRoot . '/dev/tests/acceptance';
+        $parts[] = sprintf('cp -n %s/Test/Mftf/_data/* %s/tests/_data/ 2>/dev/null || true', escapeshellarg($mountedModulePath), escapeshellarg($acceptanceDir));
+
+        // Change to acceptance test directory
         $parts[] = 'cd ' . escapeshellarg($acceptanceDir);
 
         // Bootstrap: copy clean codeception.yml to per-container tmpfs (isolated per environment)

--- a/src/Service/MftfExecutorService.php
+++ b/src/Service/MftfExecutorService.php
@@ -226,7 +226,7 @@ class MftfExecutorService
 
         // Copy module _data files (CSV fixtures etc.) to central MFTF _data directory
         $acceptanceDir = $this->magentoRoot . '/dev/tests/acceptance';
-        $parts[] = sprintf('cp -n %s/Test/Mftf/_data/* %s/tests/_data/ 2>/dev/null || true', escapeshellarg($mountedModulePath), escapeshellarg($acceptanceDir));
+        $parts[] = sprintf('if [ -d %s/Test/Mftf/_data ]; then cp -n %s/Test/Mftf/_data/* %s/tests/_data/; fi', escapeshellarg($mountedModulePath), escapeshellarg($mountedModulePath), escapeshellarg($acceptanceDir));
 
         // Change to acceptance test directory
         $parts[] = 'cd ' . escapeshellarg($acceptanceDir);


### PR DESCRIPTION
## Summary
- Adds `cp -n` step in `MftfExecutorService::buildCommand()` to copy module `Test/Mftf/_data/*` files to Magento's central `tests/_data/` directory before test execution
- Enables `attachFile` MFTF action to find CSV test fixtures (Quick Order import files) that were previously manually placed on the server

## Context
MOEC8899 test uses `attachFile` to import CSV files into Quick Order. These files need to exist in `dev/tests/acceptance/tests/_data/` on the Magento container. Previously they were manually placed; now they're part of the `abb-custom-mftf` module and auto-copied.

## Test plan
- [ ] Run MOEC8899 test on preprod-es or stage-us — verify CSV import steps pass
- [ ] Verify other tests unaffected (`cp -n` won't overwrite existing files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure module fixture/test data files are copied into the acceptance test data directory during test setup, avoiding overwriting existing files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->